### PR TITLE
Read subchunks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ world = { path = "world", optional = true }
 
 form = { path = "form" }
 
+paletted_storage = { path = "paletted_storage" }
+
 [features]
 default = []
 world = ["dep:world"]

--- a/paletted_storage/Cargo.toml
+++ b/paletted_storage/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "paletted_storage"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+nbt = { path="../nbt" }
+byteorder = "1.5"
+bedrock_core = { path = "../bedrock_core"}
+bytes = "1.6"

--- a/paletted_storage/src/lib.rs
+++ b/paletted_storage/src/lib.rs
@@ -1,0 +1,64 @@
+use std::io::Cursor;
+use bedrock_core::stream::read::ByteStreamRead;
+use byteorder::{LittleEndian, ReadBytesExt};
+use bytes::Bytes;
+use nbt::{endian::little_endian::NbtLittleEndian, NbtTag};
+
+#[derive(Debug)]
+pub struct PalettedStorage {
+    blocks: [i32; 4096],
+    palette: Vec<NbtTag>
+}
+
+impl PalettedStorage {
+    // https://www.reddit.com/r/technicalminecraft/comments/x3pzb7/bedrock_leveldb_subchunk_format/
+    // I have no idea how this actually works tbh
+    pub fn decode(mut cur: Cursor<Vec<u8>>) -> PalettedStorage {
+        let mut out = PalettedStorage{blocks: [0; 4096], palette: Vec::new()};
+        let palette_type = cur.read_u8().expect("Missing palette type");
+        let bits_per_block = palette_type >> 1;
+        if bits_per_block == 0 {
+            
+        }
+        let blocks_per_word = 32 / bits_per_block;
+        let num_words: i32 = (4096 + Into::<i32>::into(blocks_per_word) - 1) / Into::<i32>::into(blocks_per_word);
+        let mask = (1 << bits_per_block) - 1; // assume 2s complement
+        
+        let mut pos = 0;
+        for _ in 0..num_words {
+            let mut word = cur.read_i32::<LittleEndian>().expect("Missing word");
+            for _ in 0..blocks_per_word {
+                let val = word & mask;
+                if pos == 4096 {
+                    break;
+                }
+                out.blocks[pos] = val;
+                word = word >> bits_per_block;
+                pos += 1;
+            }
+        }
+
+        let palette_count = cur.read_i32::<LittleEndian>().expect("Missing palette count");
+
+        // this is where the bytes::Bytes really hurt
+        let mut bsr = ByteStreamRead::from_bytes(cursor_to_bytes(cur));
+
+        for _ in 0..palette_count {
+            out.palette.push(NbtTag::nbt_deserialize::<NbtLittleEndian>(&mut bsr).expect("Bad NBT Tag in palette").1);
+        }
+
+        return out;
+    }
+}
+
+fn cursor_to_bytes(mut cursor: Cursor<Vec<u8>>) -> Bytes { // ugly chatgpt hack because bytes::Bytes is awkward
+    // Get the current position of the cursor
+    let position = cursor.position() as usize;
+    
+    // Split the underlying Vec<u8> at the current position
+    let buffer = cursor.get_mut();
+    let remaining_data = buffer.split_off(position);
+
+    // Convert the remaining data into Bytes
+    Bytes::from(remaining_data)
+}

--- a/world/Cargo.toml
+++ b/world/Cargo.toml
@@ -5,7 +5,9 @@ edition = "2021"
 
 [dependencies]
 bedrock_core = { path = "../bedrock_core" }
+paletted_storage = { path = "../paletted_storage" }
 nbt = { path = "../nbt" }
 
 mojang-leveldb = "0.2"
 thiserror = "1.0"
+byteorder = "1.5"

--- a/world/src/world_db/mod.rs
+++ b/world/src/world_db/mod.rs
@@ -3,3 +3,4 @@ pub use key::*;
 
 pub mod world_db;
 pub mod key;
+pub mod subchunk;

--- a/world/src/world_db/subchunk.rs
+++ b/world/src/world_db/subchunk.rs
@@ -2,8 +2,9 @@ use byteorder::ReadBytesExt;
 use paletted_storage::PalettedStorage;
 use std::io::Cursor;
 
+#[derive(Debug)]
 pub struct SubChunk {
-    pub paletted_storage: PalettedStorage
+    pub paletted_storage: Vec<PalettedStorage>
 }
 
 
@@ -14,20 +15,26 @@ impl SubChunk {
         let ver = cur.read_u8().expect("Missing subchunk version");
         match ver {
             8 | 9 => {
+                let mut out = SubChunk{paletted_storage: Vec::new()};
                 let storage_layers = cur.read_u8().expect("Missing storage layers");
-                let mut y_index = None;
+                // let mut y_index = None;
                 if ver == 9 {
-                    y_index = Some(cur.read_u8().expect("Missing Y index"));
+                    // idk if we need the y index or not yet
+                    // y_index = Some(
+                        cur.read_u8().expect("Missing Y index");
+                    // );
+                }
+                
+                for i in 0..storage_layers {
+                    println!("layer: {}, count: {}", i, storage_layers);
+                    out.paletted_storage.push(PalettedStorage::decode(&mut cur));
                 }
 
-                println!("storage_layers:{}", storage_layers);
-                println!("y-index:{:?}", y_index);
-                
-                SubChunk{paletted_storage: PalettedStorage::decode(cur)}
+                out
             },
 
             1 => {
-                todo!("Subchunk V1");
+                SubChunk{paletted_storage: vec![PalettedStorage::decode(&mut cur)]}
             }
 
             a => {panic!("Unsupported subchunk version {}", a);}

--- a/world/src/world_db/subchunk.rs
+++ b/world/src/world_db/subchunk.rs
@@ -1,0 +1,36 @@
+use byteorder::ReadBytesExt;
+use paletted_storage::PalettedStorage;
+use std::io::Cursor;
+
+pub struct SubChunk {
+    pub paletted_storage: PalettedStorage
+}
+
+
+
+impl SubChunk {
+    pub fn load(bytes: Vec<u8>) -> SubChunk {
+        let mut cur = Cursor::new(bytes);
+        let ver = cur.read_u8().expect("Missing subchunk version");
+        match ver {
+            8 | 9 => {
+                let storage_layers = cur.read_u8().expect("Missing storage layers");
+                let mut y_index = None;
+                if ver == 9 {
+                    y_index = Some(cur.read_u8().expect("Missing Y index"));
+                }
+
+                println!("storage_layers:{}", storage_layers);
+                println!("y-index:{:?}", y_index);
+                
+                SubChunk{paletted_storage: PalettedStorage::decode(cur)}
+            },
+
+            1 => {
+                todo!("Subchunk V1");
+            }
+
+            a => {panic!("Unsupported subchunk version {}", a);}
+        }
+    }
+}


### PR DESCRIPTION
I created the paletted storage as its own crate because it's used in the network as well, so when chunk sending is done that can be used.

I also ran into an issue with ByteStreams, as you can see from the code. I *really* think we should go back to using cursors.

I also haven't implemented V1 yet, but I'll get that done shortly.