### PR TITLE
Fix modal form packets' names

### DIFF
--- a/proto/src/gamepacket.rs
+++ b/proto/src/gamepacket.rs
@@ -13,8 +13,8 @@ use crate::packets::handshake_server_to_client::HandshakeServerToClientPacket;
 use crate::packets::interact::InteractPacket;
 use crate::packets::level_chunk::LevelChunkPacket;
 use crate::packets::login::LoginPacket;
-use crate::packets::model_form_request::ModelFormRequestPacket;
-use crate::packets::model_form_response::ModelFormResponsePacket;
+use crate::packets::modal_form_request::ModalFormRequestPacket;
+use crate::packets::modal_form_response::ModalFormResponsePacket;
 use crate::packets::network_settings::NetworkSettingsPacket;
 use crate::packets::network_settings_request::NetworkSettingsRequestPacket;
 use crate::packets::packet_violation_warning::PacketViolationWarningPacket;
@@ -132,8 +132,8 @@ pub enum GamePacket {
     BookEdit(),
     NpcRequest(),
     PhotoTransfer(),
-    ModalFormRequest(ModelFormRequestPacket),
-    ModalFormResponse(ModelFormResponsePacket),
+    ModalFormRequest(ModalFormRequestPacket),
+    ModalFormResponse(ModalFormResponsePacket),
     ServerSettingsRequest(ServerSettingsRequestPacket),
     ServerSettingsResponse(ServerSettingsResponsePacket),
     ShowProfile(),
@@ -1161,10 +1161,10 @@ impl GamePacket {
                 unimplemented!()
             }
             GamePacket::ModalFormRequestID => {
-                GamePacket::ModalFormRequest(de_packet!(stream, ModelFormRequestPacket))
+                GamePacket::ModalFormRequest(de_packet!(stream, ModalFormRequestPacket))
             }
             GamePacket::ModalFormResponseID => {
-                GamePacket::ModalFormResponse(de_packet!(stream, ModelFormResponsePacket))
+                GamePacket::ModalFormResponse(de_packet!(stream, ModalFormResponsePacket))
             }
             GamePacket::ServerSettingsRequestID => {
                 GamePacket::ServerSettingsRequest(de_packet!(stream, ServerSettingsRequestPacket))

--- a/proto/src/packets/mod.rs
+++ b/proto/src/packets/mod.rs
@@ -20,6 +20,6 @@ pub mod player_move;
 pub mod level_chunk;
 pub mod server_settings_request;
 pub mod server_settings_response;
-pub mod model_form_request;
-pub mod model_form_response;
+pub mod modal_form_request;
+pub mod modal_form_response;
 pub mod text_message;

--- a/proto/src/packets/modal_form_request.rs
+++ b/proto/src/packets/modal_form_request.rs
@@ -2,7 +2,7 @@ use bedrockrs_core::int::VAR;
 use bedrockrs_proto_derive::ProtoCodec;
 
 #[derive(ProtoCodec, Debug, Clone)]
-pub struct ModelFormRequestPacket {
+pub struct ModalFormRequestPacket {
     pub form_id: VAR<u32>,
     pub form_json: String,
 }

--- a/proto/src/packets/modal_form_response.rs
+++ b/proto/src/packets/modal_form_response.rs
@@ -3,7 +3,7 @@ use bedrockrs_proto_derive::ProtoCodec;
 use crate::types::modal_form_cancel_reason::ModalFormCancelReason;
 
 #[derive(ProtoCodec, Debug, Clone)]
-pub struct ModelFormResponsePacket {
+pub struct ModalFormResponsePacket {
     pub form_id: VAR<u32>,
     pub form_response: Option<String>,
     pub cancel_reason: Option<ModalFormCancelReason>,


### PR DESCRIPTION
Fix the names of [ModalFormRequestPacket](https://github.com/Mojang/bedrock-protocol-docs/blob/main/html/svg/ModalFormRequestPacket.svg) and [ModalFormResponsePacket](https://github.com/Mojang/bedrock-protocol-docs/blob/main/html/svg/ModalFormResponsePacket.svg)