### PR TITLE
Restrict Github CI permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ name: Continuous integration
 jobs:
   check:
     name: Check
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -20,6 +23,9 @@ jobs:
 
   test:
     name: Test Suite
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -35,6 +41,9 @@ jobs:
 
   fmt:
     name: Rustfmt
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -51,6 +60,9 @@ jobs:
 
   clippy:
     name: Clippy
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Restricts the GitHub CI permissions to only have read access to the repository. They should only have write access to pull requests.

