### PR TITLE
Resolve `jsonwebtoken` Dependabot alerts

### DIFF
--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4"
 vek = "0.17"
 thiserror = "2.0"
 
-jsonwebtoken = "9.3"
+jsonwebtoken = "10.3"
 rand = "0.10"
 base64 = "0.22"
 uuid = { version = "1.11", features = ["v4"] }

--- a/crates/proto_core/Cargo.toml
+++ b/crates/proto_core/Cargo.toml
@@ -19,6 +19,6 @@ vek = "0.17"
 thiserror = "2.0"
 
 serde_json = "1.0"
-jsonwebtoken = "9.3"
+jsonwebtoken = "10.3"
 base64 = "0.22"
 uuid = { version = "1.11", features = ["v4"] }


### PR DESCRIPTION
Updates the `jsonwebtoken` crate to latest to resolve the Dependabot security alerts from version 9.3.

