### PR TITLE
Do not run CI on push to branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ on: [ push, pull_request ]
 
 name: Continuous integration
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+#   cancel-in-progress: true
 
 jobs:
   test-thing:


### PR DESCRIPTION
Is there a point in running CI on push? I think it's probably easier to just run for PRs instead?

Right now we run the same CI actions twice any time you push to an active PR (both push and pull_request actions) and I don't think there's much of a point in running CI on main when changes are being checked in pull requests anyways. The only use I guess I could see is running actions on non-main branches but I feel like it's not that useful since those branches would be WIP anyways.