### PR TITLE
Remove Rust CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,8 +45,7 @@ jobs:
         include:
         - language: actions
           build-mode: none
-        - language: rust
-          build-mode: none
+
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both


### PR DESCRIPTION
Removes the Rust language from the CodeQL actions, since it usually takes way too long. Workflows themselves will still be scanned but that tends to finish in a few seconds. 

Clippy should be enough to cover our needs.