### PR TITLE
Remove `vek` from the level crate

### DIFF
--- a/crates/level/Cargo.toml
+++ b/crates/level/Cargo.toml
@@ -28,7 +28,6 @@ nbtx = { workspace = true }
 
 thiserror = { workspace = true }
 serde = { workspace = true }
-vek = { workspace = true }
 byteorder = { workspace = true }
 bytemuck = { workspace = true }
 smallvec = "1.15.1"

--- a/crates/level/benches/subchunk.rs
+++ b/crates/level/benches/subchunk.rs
@@ -9,7 +9,6 @@ use bedrockrs_level::{
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use flate2::read::GzDecoder;
 use tar::Archive;
-use vek::Vec3;
 
 fn extract_test_db() -> tempfile::TempDir {
     let tmp = tempfile::tempdir().expect("Failed to create temp dir");
@@ -65,7 +64,7 @@ fn benchmark(c: &mut Criterion) {
             let data = Vec::from(kv.value());
 
             if let KeyVariant::SubChunk { index } = key.data {
-                Some((Vec3::new(key.chunk.x, index as i32, key.chunk.y), data))
+                Some(([key.chunk.0, index as i32, key.chunk.1], data))
             } else {
                 None
             }
@@ -77,12 +76,12 @@ fn benchmark(c: &mut Criterion) {
     for (key, chunk) in &chunks {
         group1.throughput(criterion::Throughput::Bytes(chunk.len() as u64));
         group1.bench_with_input(
-            BenchmarkId::from_parameter(format!("lazy {key}")),
+            BenchmarkId::from_parameter(format!("lazy {key:?}")),
             chunk,
             |b, chunk| b.iter(|| lazy_load_benchmark(chunk)),
         );
         group1.bench_with_input(
-            BenchmarkId::from_parameter(format!("greedy {key}")),
+            BenchmarkId::from_parameter(format!("greedy {key:?}")),
             chunk,
             |b, chunk| b.iter(|| greedy_load_benchmark(chunk)),
         );
@@ -99,12 +98,12 @@ fn benchmark(c: &mut Criterion) {
 
         group2.throughput(criterion::Throughput::Elements(4096));
         group2.bench_with_input(
-            BenchmarkId::from_parameter(format!("greedy {key}")),
+            BenchmarkId::from_parameter(format!("greedy {key:?}")),
             &greedy_chunk,
             |b, chunk| b.iter(|| greedy_iter_benchmark(chunk)),
         );
         group2.bench_with_input(
-            BenchmarkId::from_parameter(format!("lazy {key}")),
+            BenchmarkId::from_parameter(format!("lazy {key:?}")),
             &lazy_chunk,
             |b, chunk| b.iter(|| lazy_iter_benchmark(chunk)),
         );

--- a/crates/level/src/key.rs
+++ b/crates/level/src/key.rs
@@ -1,8 +1,10 @@
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use nbtx::LittleEndian;
-use vek::Vec2;
 
-use crate::error::{Error, Result};
+use crate::{
+    error::{Error, Result},
+    types::ChunkPosition,
+};
 use bedrockrs_shared::read::SeekExt;
 use bedrockrs_shared::world::dimension::Dimension;
 use std::io::{Cursor, Read, Seek, Write};
@@ -11,7 +13,7 @@ pub const AUTONOMOUS_ENTITIES: &str = "AutonomousEntities";
 pub const LOCAL_PLAYER: &str = "~local_player";
 pub const VILLAGES: &str = "mVillages";
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum KeyVariant {
     Biome3d = 0x2b,
@@ -68,10 +70,10 @@ impl KeyVariant {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Key {
     /// The X and Z coordinates of the requested chunk.
-    pub chunk: Vec2<i32>,
+    pub chunk: ChunkPosition,
     /// The dimension of the requested chunk.
     pub dimension: Dimension,
     /// The data to be requested of this chunk.
@@ -96,8 +98,8 @@ impl Key {
     }
 
     pub fn serialize<W: Write>(&self, mut writer: W) -> Result<()> {
-        writer.write_i32::<LittleEndian>(self.chunk.x)?;
-        writer.write_i32::<LittleEndian>(self.chunk.y)?;
+        writer.write_i32::<LittleEndian>(self.chunk.0)?;
+        writer.write_i32::<LittleEndian>(self.chunk.1)?;
 
         if self.dimension != Dimension::Overworld {
             writer.write_i32::<LittleEndian>(self.dimension as i32)?;
@@ -121,7 +123,7 @@ impl Key {
         let x = reader.read_i32::<LittleEndian>()?;
         let z = reader.read_i32::<LittleEndian>()?;
 
-        let chunk = Vec2::new(x, z);
+        let chunk = ChunkPosition(x, z);
         let dimension = if len > 10 {
             Dimension::from(reader.read_u32::<LittleEndian>()? as i32)
         } else {

--- a/crates/level/src/lib.rs
+++ b/crates/level/src/lib.rs
@@ -1,5 +1,3 @@
-pub use vek;
-
 pub mod biome;
 pub mod bits;
 pub mod error;
@@ -10,6 +8,7 @@ pub mod player;
 pub mod settings;
 pub mod subchunk;
 pub mod traits;
+pub mod types;
 
 #[cfg(feature = "mojang-leveldb")]
 pub mod mojang;

--- a/crates/level/src/player.rs
+++ b/crates/level/src/player.rs
@@ -1,6 +1,6 @@
 use crate::settings::Abilities;
+use bedrockrs_shared::vector::{Position, Rotation};
 use serde::{Deserialize, Serialize};
-use vek::{Vec2, Vec3};
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "PascalCase")]
@@ -79,7 +79,7 @@ pub struct PlayerData {
     pub is_gliding: bool,
     pub player_game_mode: i32,
     pub color: i8,
-    pub rotation: Vec2<f32>,
+    pub rotation: Rotation,
     pub invulnerable: bool,
     pub is_angry: bool,
     pub active_effects: Vec<StatusEffect>,
@@ -109,7 +109,7 @@ pub struct PlayerData {
     #[serde(rename = "hasBoundOrigin")]
     pub has_bound_origin: bool,
     pub is_tamed: bool,
-    pub pos: Vec3<f32>,
+    pub pos: Position,
     pub map_index: i32,
     #[serde(rename = "boundX")]
     pub bound_x: i32,

--- a/crates/level/src/subchunk.rs
+++ b/crates/level/src/subchunk.rs
@@ -9,10 +9,10 @@ use nbtx::LittleEndian;
 use nohash_hasher::BuildNoHashHasher;
 use rustc_hash::FxHasher;
 use serde::{Deserialize, Serialize};
-use vek::Vec3;
 
 use crate::bits::{BitArray, BitArrayIter, IndicesType};
 use crate::error::{Error, Result};
+use crate::types::BlockPosition;
 use crate::{Greedy, Lazy, UnpackingMethod};
 
 /// Version of the subchunk.
@@ -174,7 +174,7 @@ impl Layer {
     }
 
     /// Retrieves the block at `position`.
-    pub fn get<K: Into<Vec3<u8>>>(&self, position: K) -> Option<&BlockDef> {
+    pub fn get<K: Into<BlockPosition>>(&self, position: K) -> Option<&BlockDef> {
         let pos = position.into();
         let offset = to_offset(pos);
         let index = self.array.get(offset)?;
@@ -184,7 +184,7 @@ impl Layer {
     /// Sets the block at `position` to `block`.
     ///
     ///
-    pub fn set<K: Into<Vec3<u8>>>(&mut self, position: K, block: BlockDef) {
+    pub fn set<K: Into<BlockPosition>>(&mut self, position: K, block: BlockDef) {
         // Check whether the block is in the palette
         let hash = Self::hash_def(&block);
         let palette_index = *self.hashes.entry(hash).or_insert_with(|| {
@@ -310,7 +310,7 @@ impl<'a> IntoIterator for &'a Layer {
 
 impl<I> Index<I> for Layer
 where
-    I: Into<Vec3<u8>>,
+    I: Into<BlockPosition>,
 {
     type Output = BlockDef;
 
@@ -331,20 +331,20 @@ where
 ///
 /// These coordinates should be in the range [0, 16) for each component.
 #[inline]
-pub const fn to_offset(position: Vec3<u8>) -> usize {
-    16 * 16 * position.x as usize + 16 * position.z as usize + position.y as usize
+pub const fn to_offset(position: BlockPosition) -> usize {
+    16 * 16 * position.0 as usize + 16 * position.2 as usize + position.1 as usize
 }
 
 /// Converts an offset back to coordinates.
 ///
 /// This offset should be in the range [0, 4096).
 #[inline]
-pub const fn from_offset(offset: usize) -> Vec3<u8> {
+pub const fn from_offset(offset: usize) -> BlockPosition {
     let x = (offset >> 8) as u8 & 0xf;
     let y = offset as u8 & 0xf;
     let z = (offset >> 4) as u8 & 0xf;
 
-    Vec3::new(x, y, z)
+    BlockPosition(x, y, z)
 }
 
 /// A Minecraft sub chunk.

--- a/crates/level/src/types.rs
+++ b/crates/level/src/types.rs
@@ -1,0 +1,32 @@
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BlockPosition(pub u8, pub u8, pub u8);
+
+impl From<(u8, u8, u8)> for BlockPosition {
+    fn from((x, y, z): (u8, u8, u8)) -> Self {
+        Self(x, y, z)
+    }
+}
+
+impl From<[u8; 3]> for BlockPosition {
+    fn from([x, y, z]: [u8; 3]) -> Self {
+        Self(x, y, z)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SubChunkPosition(pub i32, pub i8, pub i32);
+
+impl From<(i32, i8, i32)> for SubChunkPosition {
+    fn from((x, y, z): (i32, i8, i32)) -> Self {
+        Self(x, y, z)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ChunkPosition(pub i32, pub i32);
+
+impl From<(i32, i32)> for ChunkPosition {
+    fn from((x, z): (i32, i32)) -> Self {
+        Self(x, z)
+    }
+}

--- a/crates/level/tests/test.rs
+++ b/crates/level/tests/test.rs
@@ -2,16 +2,18 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::Cursor;
 
+use bedrockrs_level::Greedy;
 use bedrockrs_level::biome::Biomes;
 use bedrockrs_level::player::PlayerData;
 use bedrockrs_level::settings::LevelSettings;
 use bedrockrs_level::subchunk::BlockDef;
-use bedrockrs_level::{Greedy, Lazy};
+use bedrockrs_level::types::BlockPosition;
 use bedrockrs_level::{
     db::Database,
     key::{Key, KeyVariant},
     subchunk::SubChunk,
 };
+
 use flate2::read::GzDecoder;
 use tar::Archive;
 
@@ -90,7 +92,7 @@ fn read_biome() {
 
                 assert_eq!(biome, biome2);
 
-                // println!("{biome:?}");
+                println!("{biome:?}");
 
                 // break
             }
@@ -123,7 +125,7 @@ fn read_subchunk() {
                 let layer = chunk.get_layer_mut(0).unwrap();
                 for i in 0..40 {
                     layer.set(
-                        vek::Vec3::new(0, i, 0),
+                        BlockPosition(0, i, 0),
                         BlockDef {
                             name: "test".to_string(),
                             states: HashMap::from([(

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -11,3 +11,4 @@ tracing = { workspace = true }
 
 byteorder = { workspace = true }
 varint-rs = { workspace = true }
+serde.workspace = true

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod actor_runtime_id;
 pub mod actor_unique_id;
 pub mod read;
+pub mod vector;
 pub mod world;

--- a/crates/shared/src/vector.rs
+++ b/crates/shared/src/vector.rs
@@ -1,0 +1,30 @@
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+pub struct Position(pub f32, pub f32, pub f32);
+
+impl From<(f32, f32, f32)> for Position {
+    fn from((x, y, z): (f32, f32, f32)) -> Self {
+        Self(x, y, z)
+    }
+}
+
+impl From<[f32; 3]> for Position {
+    fn from([x, y, z]: [f32; 3]) -> Self {
+        Self(x, y, z)
+    }
+}
+
+/// Rotation of an entity.
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+pub struct Rotation(pub f32, pub f32);
+
+impl From<(f32, f32)> for Rotation {
+    fn from((x, y): (f32, f32)) -> Self {
+        Self(x, y)
+    }
+}
+
+impl From<[f32; 2]> for Rotation {
+    fn from([x, y]: [f32; 2]) -> Self {
+        Self(x, y)
+    }
+}


### PR DESCRIPTION
Removes the `vek` dependency from the level crate, as was also done in proto

