### PR TITLE
chore: make metadata, dependencies field optional in manifest

### DIFF
--- a/crates/addon/src/manifest.rs
+++ b/crates/addon/src/manifest.rs
@@ -14,11 +14,12 @@ pub struct AddonManifest {
     /// Section containing information regarding the type of content that is being brought in.
     pub modules: Vec<AddonManifestModule>,
     /// Section containing definitions for any other packs that are required in order for this manifest.json file to work.
+    #[serde(default)]
     pub dependencies: Vec<AddonManifestDependency>,
     /// Section containing optional features that can be enabled in Minecraft.
     pub capabilities: Option<Vec<String>>,
     /// Section containing the metadata about the file such as authors and licensing information.
-    pub metadata: AddonManifestMetadata,
+    pub metadata: Option<AddonManifestMetadata>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
In my opinion those fields aren't required and shouldn't be required.