### PR TITLE
Fix several packet divergences

### DIFF
--- a/crates/protocol/src/version/v1001/packets/start_game.rs
+++ b/crates/protocol/src/version/v1001/packets/start_game.rs
@@ -38,8 +38,8 @@ pub struct StartGamePacket<V: ProtoVersion> {
     pub is_logging_chat: bool,
     pub server_join_information: Option<ServerJoinInformation>,
     pub server_id: String,
-    pub world_id: String,
     pub scenario_id: String,
+    pub world_id: String,
     pub owner_id: String,
 }
 
@@ -59,13 +59,13 @@ pub struct ServerJoinInformation {
 
 #[derive(ProtoCodec, Clone, Debug)]
 pub struct GatheringJoinInfo {
-    pub experience_id: String,
-    pub experience_name: Option<String>,
-    pub experience_world_id: String,
-    pub experience_world_name: Option<String>,
+    pub experience_id: Uuid,
+    pub experience_name: String,
+    pub experience_world_id: Uuid,
+    pub experience_world_name: String,
     pub creator_id: String,
-    pub unknown1: Uuid, // TODO: find out what this is
-    pub unknown2: Uuid, // TODO: find out what this is
+    pub target_id: Uuid,
+    pub scenario_id: String,
     pub server_id: String,
 }
 

--- a/crates/protocol/src/version/v1001/packets/sub_chunk_request.rs
+++ b/crates/protocol/src/version/v1001/packets/sub_chunk_request.rs
@@ -6,8 +6,6 @@ use bedrock_macros::{packet, ProtoCodec};
 pub struct SubChunkRequestPacket<V: ProtoVersion> {
     #[endianness(var)]
     pub dimension_type: i32,
-    #[vec_repr(u32)]
-    #[vec_endianness(le)]
     pub sub_chunk_pos_offsets: Vec<V::SubChunkPosOffset>,
     #[endianness(le)]
     pub center_pos: (i32, i32, i32),

--- a/crates/protocol/src/version/v1001/types/debug_shape.rs
+++ b/crates/protocol/src/version/v1001/types/debug_shape.rs
@@ -11,7 +11,7 @@ pub struct DebugShape<V: ProtoVersion> {
     #[endianness(le)]
     pub scale: Option<f32>,
     #[endianness(le)]
-    pub rotation: Option<(f32, f32)>,
+    pub rotation: Option<(f32, f32, f32)>,
     #[endianness(le)]
     pub remaining_duration: Option<f32>,
     #[endianness(le)]

--- a/crates/protocol/src/version/v662/enums/soft_enum_update_type.rs
+++ b/crates/protocol/src/version/v662/enums/soft_enum_update_type.rs
@@ -1,9 +1,8 @@
 use bedrock_macros::ProtoCodec;
 
 #[derive(ProtoCodec, Clone, Debug)]
-#[enum_repr(u32)]
-#[enum_endianness(le)]
-#[repr(u32)]
+#[enum_repr(u8)]
+#[repr(u8)]
 pub enum SoftEnumUpdateType {
     Add = 0,
     Remove = 1,

--- a/crates/protocol/src/version/v662/packets/item_stack_request.rs
+++ b/crates/protocol/src/version/v662/packets/item_stack_request.rs
@@ -10,7 +10,7 @@ pub struct ItemStackRequestPacket<V: ProtoVersion> {
 #[derive(ProtoCodec, Clone, Debug)]
 pub struct RequestsEntry<V: ProtoVersion> {
     #[endianness(var)]
-    pub client_request_id: u32,
+    pub client_request_id: i32,
     pub actions: Vec<V::ItemStackRequestActionType>,
     pub strings_to_filter: Vec<String>,
     pub strings_to_filter_origin: V::TextProcessingEventOrigin,

--- a/crates/protocol/src/version/v662/types/move_actor_delta_data.rs
+++ b/crates/protocol/src/version/v662/types/move_actor_delta_data.rs
@@ -1,18 +1,125 @@
 use crate::ProtoVersion;
-use bedrock_macros::ProtoCodec;
+use bedrock_protocol_core::error::ProtoCodecError;
+use bedrock_protocol_core::{ProtoCodec, ProtoCodecLE};
+use std::io::{Read, Write};
 
-#[derive(ProtoCodec, Clone, Debug)]
+// Header bitfield flags
+const FLAG_HAS_X: u16 = 0x01;
+const FLAG_HAS_Y: u16 = 0x02;
+const FLAG_HAS_Z: u16 = 0x04;
+const FLAG_HAS_PITCH: u16 = 0x08; // rotation_x
+const FLAG_HAS_YAW: u16 = 0x10; // rotation_y
+const FLAG_HAS_HEAD_YAW: u16 = 0x20; // rotation_y_head
+
+#[derive(Clone, Debug)]
 pub struct MoveActorDeltaData<V: ProtoVersion> {
     pub actor_runtime_id: V::ActorRuntimeID,
-    #[endianness(le)]
     pub header: u16,
-    #[endianness(le)]
     pub position_x: f32,
-    #[endianness(le)]
     pub position_y: f32,
-    #[endianness(le)]
     pub position_z: f32,
     pub rotation_x: i8,
     pub rotation_y: i8,
     pub rotation_y_head: i8,
+}
+
+impl<V: ProtoVersion> ProtoCodec for MoveActorDeltaData<V> {
+    fn serialize<W: Write>(&self, stream: &mut W) -> Result<(), ProtoCodecError> {
+        <V::ActorRuntimeID as ProtoCodec>::serialize(&self.actor_runtime_id, stream)?;
+        <u16 as ProtoCodecLE>::serialize(&self.header, stream)?;
+
+        if self.header & FLAG_HAS_X != 0 {
+            <f32 as ProtoCodecLE>::serialize(&self.position_x, stream)?;
+        }
+        if self.header & FLAG_HAS_Y != 0 {
+            <f32 as ProtoCodecLE>::serialize(&self.position_y, stream)?;
+        }
+        if self.header & FLAG_HAS_Z != 0 {
+            <f32 as ProtoCodecLE>::serialize(&self.position_z, stream)?;
+        }
+        if self.header & FLAG_HAS_PITCH != 0 {
+            <i8 as ProtoCodec>::serialize(&self.rotation_x, stream)?;
+        }
+        if self.header & FLAG_HAS_YAW != 0 {
+            <i8 as ProtoCodec>::serialize(&self.rotation_y, stream)?;
+        }
+        if self.header & FLAG_HAS_HEAD_YAW != 0 {
+            <i8 as ProtoCodec>::serialize(&self.rotation_y_head, stream)?;
+        }
+
+        Ok(())
+    }
+
+    fn deserialize<R: Read>(stream: &mut R) -> Result<Self, ProtoCodecError> {
+        let actor_runtime_id = <V::ActorRuntimeID as ProtoCodec>::deserialize(stream)?;
+        let header = <u16 as ProtoCodecLE>::deserialize(stream)?;
+
+        let position_x = if header & FLAG_HAS_X != 0 {
+            <f32 as ProtoCodecLE>::deserialize(stream)?
+        } else {
+            0.0
+        };
+        let position_y = if header & FLAG_HAS_Y != 0 {
+            <f32 as ProtoCodecLE>::deserialize(stream)?
+        } else {
+            0.0
+        };
+        let position_z = if header & FLAG_HAS_Z != 0 {
+            <f32 as ProtoCodecLE>::deserialize(stream)?
+        } else {
+            0.0
+        };
+        let rotation_x = if header & FLAG_HAS_PITCH != 0 {
+            <i8 as ProtoCodec>::deserialize(stream)?
+        } else {
+            0
+        };
+        let rotation_y = if header & FLAG_HAS_YAW != 0 {
+            <i8 as ProtoCodec>::deserialize(stream)?
+        } else {
+            0
+        };
+        let rotation_y_head = if header & FLAG_HAS_HEAD_YAW != 0 {
+            <i8 as ProtoCodec>::deserialize(stream)?
+        } else {
+            0
+        };
+
+        Ok(Self {
+            actor_runtime_id,
+            header,
+            position_x,
+            position_y,
+            position_z,
+            rotation_x,
+            rotation_y,
+            rotation_y_head,
+        })
+    }
+
+    fn size_hint(&self) -> usize {
+        let mut size = <V::ActorRuntimeID as ProtoCodec>::size_hint(&self.actor_runtime_id);
+        size += 2; // header (u16)
+
+        if self.header & FLAG_HAS_X != 0 {
+            size += 4; // position_x (f32)
+        }
+        if self.header & FLAG_HAS_Y != 0 {
+            size += 4; // position_y (f32)
+        }
+        if self.header & FLAG_HAS_Z != 0 {
+            size += 4; // position_z (f32)
+        }
+        if self.header & FLAG_HAS_PITCH != 0 {
+            size += 1; // rotation_x (i8)
+        }
+        if self.header & FLAG_HAS_YAW != 0 {
+            size += 1; // rotation_y (i8)
+        }
+        if self.header & FLAG_HAS_HEAD_YAW != 0 {
+            size += 1; // rotation_y_head (i8)
+        }
+
+        size
+    }
 }

--- a/crates/protocol/src/version/v662/types/serialized_abilities_data.rs
+++ b/crates/protocol/src/version/v662/types/serialized_abilities_data.rs
@@ -8,6 +8,7 @@ pub struct SerializedAbilitiesData<V: ProtoVersion> {
     pub player_permissions: V::PlayerPermissionLevel,
     pub command_permissions: V::CommandPermissionLevel,
 
+    #[vec_repr(u8)]
     pub layers: Vec<SerializedLayer>,
 }
 

--- a/crates/protocol/src/version/v712/packets/camera_instruction.rs
+++ b/crates/protocol/src/version/v712/packets/camera_instruction.rs
@@ -5,5 +5,4 @@ use bedrock_macros::{packet, ProtoCodec};
 #[derive(ProtoCodec, Clone, Debug)]
 pub struct CameraInstructionPacket<V: ProtoVersion> {
     pub camera_instruction: V::CameraInstruction,
-    pub remove_target: Option<bool>,
 }

--- a/crates/protocol/src/version/v712/types/camera_instruction.rs
+++ b/crates/protocol/src/version/v712/types/camera_instruction.rs
@@ -7,6 +7,7 @@ pub struct CameraInstruction<V: ProtoVersion> {
     pub clear: Option<bool>,
     pub fade: Option<FadeInstruction>,
     pub target: Option<TargetInstruction<V>>,
+    pub remove_target: Option<bool>,
 }
 
 // VERIFY: SetInstruction & FadeInstruction

--- a/crates/protocol/src/version/v748/types/camera_instruction.rs
+++ b/crates/protocol/src/version/v748/types/camera_instruction.rs
@@ -7,6 +7,7 @@ pub struct CameraInstruction<V: ProtoVersion> {
     pub clear: Option<bool>,
     pub fade: Option<FadeInstruction>,
     pub target: Option<TargetInstruction<V>>,
+    pub remove_target: Option<bool>,
 }
 
 // VERIFY: SetInstruction & FadeInstruction

--- a/crates/protocol/src/version/v766/packets/player_auth_input.rs
+++ b/crates/protocol/src/version/v766/packets/player_auth_input.rs
@@ -6,6 +6,7 @@ use player_auth_input_packet::{
     ClientPredictedVehicleData, PerformItemStackRequestData, PlayerAuthInputFlags,
 };
 use std::io::{Read, Write};
+use varint_rs::{VarintReader, VarintWriter};
 
 #[packet(id = 144)]
 #[derive(Clone, Debug)]
@@ -116,7 +117,7 @@ pub mod player_auth_input_packet {
     #[derive(ProtoCodec, Clone, Debug)]
     pub struct PerformItemStackRequestData<V: ProtoVersion> {
         #[endianness(var)]
-        pub client_request_id: u32,
+        pub client_request_id: i32,
         pub actions: Vec<ActionsEntry<V>>,
         pub strings_to_filter: Vec<String>,
         pub strings_to_filter_origin: V::TextProcessingEventOrigin,
@@ -156,10 +157,11 @@ impl<V: ProtoVersion> ProtoCodec for PlayerAuthInputPacket<V> {
             )?;
         }
         if self.input_data & PlayerAuthInputFlags::PerformBlockActions as u128 != 0 {
-            <Vec<V::PlayerBlockActionData> as ProtoCodec>::serialize(
-                self.player_block_actions.as_ref().ok_or(ProtoCodecError::ExpectedSome("player_block_actions"))?,
-                stream,
-            )?;
+            let vec = self.player_block_actions.as_ref().ok_or(ProtoCodecError::ExpectedSome("player_block_actions"))?;
+            stream.write_i32_varint(vec.len() as i32)?;
+            for a in vec {
+                <V::PlayerBlockActionData as ProtoCodec>::serialize(a, stream)?;
+            }
         }
         if self.input_data & PlayerAuthInputFlags::IsInClientPredictedVehicle as u128 != 0 {
             <ClientPredictedVehicleData<V> as ProtoCodec>::serialize(
@@ -204,7 +206,14 @@ impl<V: ProtoVersion> ProtoCodec for PlayerAuthInputPacket<V> {
             };
         let player_block_actions =
             match input_data & PlayerAuthInputFlags::PerformBlockActions as u128 != 0 {
-                true => Some(<Vec<V::PlayerBlockActionData> as ProtoCodec>::deserialize(stream)?),
+                true => {
+                    let len = stream.read_i32_varint()?;
+                    let mut vec = Vec::with_capacity(len.max(0) as usize);
+                    for _ in 0..len {
+                        vec.push(<V::PlayerBlockActionData as ProtoCodec>::deserialize(stream)?);
+                    }
+                    Some(vec)
+                }
                 false => None,
             };
         let client_predicted_vehicle =
@@ -261,7 +270,10 @@ impl<V: ProtoVersion> ProtoCodec for PlayerAuthInputPacket<V> {
                 false => 0,
             }
             + match self.input_data & PlayerAuthInputFlags::PerformBlockActions as u128 != 0 {
-                true => self.player_block_actions.as_ref().map_or(0, ProtoCodec::size_hint),
+                true => self.player_block_actions.as_ref().map_or(0, |vec| {
+                    <i32 as ProtoCodecVAR>::size_hint(&(vec.len() as i32))
+                        + vec.iter().map(ProtoCodec::size_hint).sum::<usize>()
+                }),
                 false => 0,
             }
             + match self.input_data & PlayerAuthInputFlags::IsInClientPredictedVehicle as u128 != 0

--- a/crates/protocol/src/version/v818/types/camera_instruction.rs
+++ b/crates/protocol/src/version/v818/types/camera_instruction.rs
@@ -7,6 +7,7 @@ pub struct CameraInstruction<V: ProtoVersion> {
     pub clear: Option<bool>,
     pub fade: Option<FadeInstruction>,
     pub target: Option<TargetInstruction<V>>,
+    pub remove_target: Option<bool>,
 }
 
 // VERIFY: SetInstruction & FadeInstruction

--- a/crates/protocol/src/version/v818/types/debug_shape.rs
+++ b/crates/protocol/src/version/v818/types/debug_shape.rs
@@ -11,7 +11,7 @@ pub struct DebugShape<V: ProtoVersion> {
     #[endianness(le)]
     pub scale: Option<f32>,
     #[endianness(le)]
-    pub rotation: Option<(f32, f32)>,
+    pub rotation: Option<(f32, f32, f32)>,
     #[endianness(le)]
     pub remaining_duration: Option<f32>,
     pub color: Option<V::Color>,

--- a/crates/protocol/src/version/v827/types/camera_instruction.rs
+++ b/crates/protocol/src/version/v827/types/camera_instruction.rs
@@ -7,6 +7,7 @@ pub struct CameraInstruction<V: ProtoVersion> {
     pub clear: Option<bool>,
     pub fade: Option<FadeInstruction>,
     pub target: Option<TargetInstruction<V>>,
+    pub remove_target: Option<bool>,
     pub field_of_view: Option<FieldOfViewInstruction<V>>,
 }
 

--- a/crates/protocol/src/version/v859/types/camera_instruction.rs
+++ b/crates/protocol/src/version/v859/types/camera_instruction.rs
@@ -7,6 +7,7 @@ pub struct CameraInstruction<V: ProtoVersion> {
     pub clear: Option<bool>,
     pub fade: Option<FadeInstruction>,
     pub target: Option<TargetInstruction<V>>,
+    pub remove_target: Option<bool>,
     pub field_of_view: Option<FieldOfViewInstruction<V>>,
     pub spline: Option<SplineInstruction<V>>,
     pub attach: Option<AttachInstruction>,

--- a/crates/protocol/src/version/v924/packets/client_bound_data_store.rs
+++ b/crates/protocol/src/version/v924/packets/client_bound_data_store.rs
@@ -26,7 +26,7 @@ pub enum ClientBoundDataStoreUpdate {
         property: String,
         #[endianness(le)]
         update_count: u32,
-        new_value: ClientBoundDataStoreValue,
+        new_value: ClientBoundDataStorePropertyValue,
     } = 1,
     Remove {
         data_store_name: String,
@@ -41,4 +41,22 @@ pub enum ClientBoundDataStoreValue {
     Double(#[endianness(le)] f64) = 0,
     Bool(bool) = 1,
     String(String) = 2,
+}
+
+#[derive(ProtoCodec, Clone, Debug)]
+#[enum_repr(i32)]
+#[enum_endianness(le)]
+#[repr(i32)]
+pub enum ClientBoundDataStorePropertyValue {
+    None = 0,
+    Bool(bool) = 1,
+    Int64(#[endianness(le)] i64) = 2,
+    String(String) = 4,
+    Map(Vec<DataStoreMapEntry>) = 6,
+}
+
+#[derive(ProtoCodec, Clone, Debug)]
+pub struct DataStoreMapEntry {
+    pub key: String,
+    pub value: ClientBoundDataStorePropertyValue,
 }

--- a/crates/protocol/src/version/v924/types/camera_instruction.rs
+++ b/crates/protocol/src/version/v924/types/camera_instruction.rs
@@ -7,6 +7,7 @@ pub struct CameraInstruction<V: ProtoVersion> {
     pub clear: Option<bool>,
     pub fade: Option<FadeInstruction>,
     pub target: Option<TargetInstruction<V>>,
+    pub remove_target: Option<bool>,
     pub field_of_view: Option<FieldOfViewInstruction<V>>,
     pub spline: Option<V::CameraSplineInstruction>,
     pub attach: Option<AttachInstruction>,

--- a/crates/protocol/src/version/v975/packets/locator_bar.rs
+++ b/crates/protocol/src/version/v975/packets/locator_bar.rs
@@ -30,9 +30,9 @@ pub struct LocatorBarWaypoint {
     pub update_flag: u32,
     pub visible: Option<bool>,
     pub world_position: Option<LocatorBarWaypointWorldPosition>,
-    pub texture_path: String,
+    pub texture_path: Option<String>,
     #[endianness(le)]
-    pub icon_size: (f32, f32),
+    pub icon_size: Option<(f32, f32)>,
     #[endianness(le)]
     pub color: Option<i32>,
     pub client_authority: Option<bool>,

--- a/crates/protocol/src/version/v975/packets/play_sound.rs
+++ b/crates/protocol/src/version/v975/packets/play_sound.rs
@@ -1,15 +1,71 @@
 use crate::ProtoVersion;
-use bedrock_macros::{packet, ProtoCodec};
+use bedrock_macros::packet;
+use bedrock_protocol_core::error::ProtoCodecError;
+use bedrock_protocol_core::{ProtoCodec, ProtoCodecLE};
+use std::io::{Read, Write};
+use std::marker::PhantomData;
+use varint_rs::{VarintReader, VarintWriter};
 
 #[packet(id = 86)]
-#[derive(ProtoCodec, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct PlaySoundPacket<V: ProtoVersion> {
     pub name: String,
-    pub position: V::NetworkBlockPosition,
-    #[endianness(le)]
+    /// World-space position. On the wire this is encoded as a fixed-point block
+    /// position (each coordinate multiplied by 8) using signed varints
+    pub position: (f32, f32, f32),
     pub volume: f32,
-    #[endianness(le)]
     pub pitch: f32,
-    #[endianness(le)]
     pub server_sound_handle: Option<i64>,
+    pub _marker: PhantomData<V>,
+}
+
+impl<V: ProtoVersion> ProtoCodec for PlaySoundPacket<V> {
+    fn serialize<W: Write>(&self, stream: &mut W) -> Result<(), ProtoCodecError> {
+        <String as ProtoCodec>::serialize(&self.name, stream)?;
+
+        // Position is encoded as a block position scaled by 8 (signed varint per coord)
+        stream.write_i32_varint((self.position.0 * 8.0).round() as i32)?;
+        stream.write_i32_varint((self.position.1 * 8.0).round() as i32)?;
+        stream.write_i32_varint((self.position.2 * 8.0).round() as i32)?;
+
+        <f32 as ProtoCodecLE>::serialize(&self.volume, stream)?;
+        <f32 as ProtoCodecLE>::serialize(&self.pitch, stream)?;
+        <Option<i64> as ProtoCodecLE>::serialize(&self.server_sound_handle, stream)?;
+
+        Ok(())
+    }
+
+    fn deserialize<R: Read>(stream: &mut R) -> Result<Self, ProtoCodecError> {
+        let name = <String as ProtoCodec>::deserialize(stream)?;
+
+        let position = (
+            stream.read_i32_varint()? as f32 / 8.0,
+            stream.read_i32_varint()? as f32 / 8.0,
+            stream.read_i32_varint()? as f32 / 8.0,
+        );
+
+        let volume = <f32 as ProtoCodecLE>::deserialize(stream)?;
+        let pitch = <f32 as ProtoCodecLE>::deserialize(stream)?;
+        let server_sound_handle = <Option<i64> as ProtoCodecLE>::deserialize(stream)?;
+
+        Ok(Self {
+            name,
+            position,
+            volume,
+            pitch,
+            server_sound_handle,
+            _marker: PhantomData,
+        })
+    }
+
+    fn size_hint(&self) -> usize {
+        let mut size = <String as ProtoCodec>::size_hint(&self.name);
+        // 3 signed varints (1..=5 bytes each); use the max as a conservative hint
+        size += 5 * 3;
+        size += 4; // volume (f32)
+        size += 4; // pitch (f32)
+        size += <Option<i64> as ProtoCodecLE>::size_hint(&self.server_sound_handle);
+
+        size
+    }
 }


### PR DESCRIPTION
Field type / structure
  - StartGame: corrected telemetry-ID order to server, scenario, world, owner; fixed GatheringJoinInfo (experience_id/experience_world_id → UUID, experience names → plain String, trailing scenario_id → String).
  - CameraInstruction: moved remove_target to its correct position (immediately after target), across all inner-type versions (v712–v924).
  - DebugDrawer: shape rotation is now a Vec3 (was 2 floats).
  - LocatorBar: waypoint texture_path and icon_size are now Optional.
  - ClientBoundDataStore: the Change variant's value now uses the rich DataStorePropertyValue (LE-i32 tag: none/bool/int64/string/recursive map) instead of the simple double/bool/string enum.

Integer encoding
  - UpdateSoftEnum update_type: u8 (was LE u32).
  - UpdateAbilities ability-layers count: u8 (was varuint32).
  - SubChunkRequest offset-list count: varuint (was fixed LE u32) — a genuine 1001 wire change.
  - ItemStackRequest client_request_id: signed (zigzag) varint (was unsigned).
  - PlayerAuthInput block-actions count: signed (zigzag) varint (was unsigned).
  - SyncWorldClocks: payload discriminant → varuint (was LE u32); TimeMarker.period → Optional<le i32>.

  Conditional / transform encoding (manual codecs)
  - MoveActorDelta: position/rotation components are now flag-gated by the header bitfield (were always written).
  - PlaySound: position is now encoded as ×8 fixed-point block coordinates (signed varints).

  Notes

  - The ClientBoundDataStore change_type and Update data_type tags were verified against Cloudburst's version-exact v924 serializer and left as varuint (already correct).
  - Cross-checked that several gophertunnel encodings (HurtArmor, MovementEffect unsigned varints; block-position signed-Y) were already correct in bedrock-rs — no changes needed there.

  Out of scope

  Pre-1001 copies of the same latent bug were left untouched (v662 play_sound, v662/v748
  PerformItemStackRequestData.client_request_id), since they don't affect protocol 1001.